### PR TITLE
MSSQL 2008 compatibility

### DIFF
--- a/RunSingleSqlScript/RunSingleSqlScript.ps1
+++ b/RunSingleSqlScript/RunSingleSqlScript.ps1
@@ -14,6 +14,12 @@ Try
 	[string]$userPassword = Get-VstsInput -Name userPassword
 	[string]$queryTimeout = Get-VstsInput -Name queryTimeout
 
+	if(!(Get-Command "Invoke-Sqlcmd" -errorAction SilentlyContinue))
+	{
+		Add-PSSnapin SqlServerCmdletSnapin100
+        Add-PSSnapin SqlServerProviderSnapin100
+	}
+
 	Write-Host "Running Script " $sqlScript " on Database " $databaseName
 		
 	#Execute the query

--- a/RunSqlCommand/RunSqlCommand.ps1
+++ b/RunSqlCommand/RunSqlCommand.ps1
@@ -15,6 +15,11 @@ Try
 	[string]$userPassword = Get-VstsInput -Name userPassword
 	[string]$queryTimeout = Get-VstsInput -Name queryTimeout
 
+	if(!(Get-Command "Invoke-Sqlcmd" -errorAction SilentlyContinue))
+	{
+		Add-PSSnapin SqlServerCmdletSnapin100
+        Add-PSSnapin SqlServerProviderSnapin100
+	}
 
 	Write-Host "Running SQl Command on Database " $databaseName
 		

--- a/RunSqlScripts/RunSqlScripts.ps1
+++ b/RunSqlScripts/RunSqlScripts.ps1
@@ -14,6 +14,12 @@ Try
 	[string]$userPassword = Get-VstsInput -Name userPassword;
 	[string]$queryTimeout = Get-VstsInput -Name queryTimeout;
 
+	if(!(Get-Command "Invoke-Sqlcmd" -errorAction SilentlyContinue))
+	{
+		Add-PSSnapin SqlServerCmdletSnapin100
+        Add-PSSnapin SqlServerProviderSnapin100
+	}
+
 	Write-Host "Running all scripts in $pathToScripts";
 
 	foreach ($f in Get-ChildItem -path "$pathToScripts" -Filter *.sql | sort-object)

--- a/RunStoredProcedure/RunStoredProcedure.ps1
+++ b/RunStoredProcedure/RunStoredProcedure.ps1
@@ -15,6 +15,11 @@ Try
 	[string]$userPassword = Get-VstsInput -Name userPassword
 	[string]$queryTimeout = Get-VstsInput -Name queryTimeout
 
+	if(!(Get-Command "Invoke-Sqlcmd" -errorAction SilentlyContinue))
+	{
+		Add-PSSnapin SqlServerCmdletSnapin100
+        Add-PSSnapin SqlServerProviderSnapin100
+	}
 
 	Write-Host "Running Stored Procedure " $sprocName " on Database " $databaseName
 	

--- a/SqlBackup/SqlBackup.ps1
+++ b/SqlBackup/SqlBackup.ps1
@@ -15,7 +15,12 @@ Try
 		[string]$userName = Get-VstsInput -Name userName
 		[string]$userPassword = Get-VstsInput -Name userPassword
         [string]$userPassword = Get-VstsInput -Name queryTimeout
-		
+
+		if(!(Get-Command "Invoke-Sqlcmd" -errorAction SilentlyContinue))
+		{
+			Add-PSSnapin SqlServerCmdletSnapin100
+			Add-PSSnapin SqlServerProviderSnapin100
+		}
 		
 		#Specify the Action property to generate a FULL backup
 		switch($backupType.ToLower())


### PR DESCRIPTION
Conditionally adding SQl Server PowerShell snapins if the Invoke-Sqlcmd cmdlet is not available. Restores compatibility with MS SQL Server 2008.
