### PR TITLE
detailed error message output

### DIFF
--- a/RunDACPAC/RunDACPAC.ps1
+++ b/RunDACPAC/RunDACPAC.ps1
@@ -58,5 +58,6 @@ Try
 catch
 {
 	Write-Error "Error running DACPAC: $_"
+	$_ | format-list -force
 }
 


### PR DESCRIPTION
This would resolve the issue #20 by displaying a detailed error message to the admin in the release log.

This is a very small change. But it would help many who use this code.