### PR TITLE
Feature: Added "Create New Database" option to "Run DACPAC" task

### DIFF
--- a/RunDACPAC/RunDACPAC.ps1
+++ b/RunDACPAC/RunDACPAC.ps1
@@ -13,6 +13,7 @@ Try
 	[string]$userName = Get-VstsInput -Name userName
 	[string]$userPassword = Get-VstsInput -Name userPassword
 	[string]$logProgress = Get-VstsInput -Name logProgress
+	[bool]$createNewDatabase = Get-VstsInput -Name createNewDatabase -AsBool
 
 	Write-Host "Running DACPAC " $packagePath " on Database " $databaseName
 		
@@ -50,7 +51,11 @@ Try
 		Register-ObjectEvent -InputObject $service -EventName "Message" -Action { Write-Host $EventArgs.Message.Message } | out-null
 	}
 	$package = [Microsoft.SqlServer.Dac.DacPackage]::Load($packagePath)
-	$service.Deploy($package, $databaseName, $true, $null, $null) 
+
+	$options = New-Object Microsoft.SqlServer.Dac.DacDeployOptions
+	$options.CreateNewDatabase = $createNewDatabase
+
+	$service.Deploy($package, $databaseName, $true, $options, $null) 
 
 	Write-Host "Finished"
 }
@@ -58,6 +63,6 @@ Try
 catch
 {
 	Write-Error "Error running DACPAC: $_"
-	$_ | format-list -force
+	$_.Exception|format-list -force|Write-Error
 }
 

--- a/RunDACPAC/task.json
+++ b/RunDACPAC/task.json
@@ -7,8 +7,8 @@
     "category": "Utility",
     "version": {
         "Major": "2",
-        "Minor": "0",
-        "Patch": "5"
+        "Minor": "1",
+        "Patch": "0"
     },
     "groups": [
         {
@@ -53,6 +53,15 @@
             "required": false,
             "groupName": "advanced",
             "helpMarkDown": "Password for SQL Authenication. You should use a secret variable here."
+        },
+        {
+            "name": "createNewDatabase",
+            "type": "boolean",
+            "label": "Create new database",
+            "defaultValue":"false",
+            "required": false,
+            "groupName": "advanced",
+            "helpMarkDown": "Specifies whether the existing database will be dropped and a new database created before proceeding with the actual deployment actions. Acquires single-user mode before dropping the existing database."
         },
         {
             "name": "logProgress",


### PR DESCRIPTION
My team uses this task to reset the database  to a baseline before running other migration tasks.  I've exposed the [CreateNewDatabase](https://msdn.microsoft.com/en-us/library/hh753343(v=sql.110).aspx) deployment option of DAC to prevent the need for using another task just to drop it in advance.  Since this is a new minor feature, I upped the version of the task to 2.1.0 but left the vss extension version as-is, since I'm not sure of your conventions.