### PR TITLE
Backup Task: Fix "Incorrect syntax near '-'." error

### DIFF
--- a/SqlBackup/SqlBackup.ps1
+++ b/SqlBackup/SqlBackup.ps1
@@ -96,7 +96,7 @@ Try {
     }
 		
     #Build the backup query using Windows Authenication
-    $sqlCommand = $checkDatabase + "BACKUP " + $backupAction + " " + $databaseName + " TO DISK = N'" + $backupFile + "' WITH " + $withOptions; 
+    $sqlCommand = $checkDatabase + "BACKUP " + $backupAction + " [" + $databaseName + "] TO DISK = N'" + $backupFile + "' WITH " + $withOptions; 
 		
     Write-Host "Starting $backupType backup of $databaseName to $backupFile"
 		


### PR DESCRIPTION
Enclose database name with brackets; fixes error when database name contains dash (like test-test)